### PR TITLE
treat integer and numeric as interchangeable

### DIFF
--- a/R/casting.R
+++ b/R/casting.R
@@ -32,16 +32,16 @@ detectColsToCast <- function(table, cols) {
   origColType <- unlist(cols[vals])
   newColType <- unlist(colTypes[vals])
   # will consider integer and numeric as interchangeable
-  origColType <- dplyr::case_when(
-    origColType == "integer"  ~ "integerish",
-    origColType == "numeric"  ~ "integerish",
-    .default = origColType
-  )
-  newColType <- dplyr::case_when(
-    origColType == "integer"  ~ "integerish",
-    origColType == "numeric"  ~ "integerish",
-    .default = newColType
-  )
+  origColType <- purrr::map_chr(origColType, ~ dplyr::case_when(
+    .x == "integer"  ~ "integerish",
+    .x == "numeric"  ~ "integerish",
+    TRUE ~ .x
+  ))
+  newColType <- purrr::map_chr(newColType, ~ dplyr::case_when(
+    .x == "integer"  ~ "integerish",
+    .x == "numeric"  ~ "integerish",
+    TRUE ~ .x
+  ))
   differentValues <- vals[origColType != newColType]
   colsToCast <- list(
     "new" = cols[differentValues], "old" = colTypes[differentValues])

--- a/R/casting.R
+++ b/R/casting.R
@@ -29,7 +29,20 @@ detectColsToCast <- function(table, cols) {
     lapply(dplyr::type_sum) |>
     lapply(assertClassification)
   vals <- intersect(names(colTypes), names(cols))
-  differentValues <- vals[unlist(cols[vals]) != unlist(colTypes[vals])]
+  origColType <- unlist(cols[vals])
+  newColType <- unlist(colTypes[vals])
+  # will consider integer and numeric as interchangeable
+  origColType <- dplyr::case_when(
+    origColType == "integer"  ~ "integerish",
+    origColType == "numeric"  ~ "integerish",
+    .default = origColType
+  )
+  newColType <- dplyr::case_when(
+    origColType == "integer"  ~ "integerish",
+    origColType == "numeric"  ~ "integerish",
+    .default = newColType
+  )
+  differentValues <- vals[origColType != newColType]
   colsToCast <- list(
     "new" = cols[differentValues], "old" = colTypes[differentValues])
   return(colsToCast)

--- a/tests/testthat/test-classCohortTable.R
+++ b/tests/testthat/test-classCohortTable.R
@@ -417,7 +417,7 @@ test_that("test that tables are casted", {
     cohort_start_date = as.Date(c("2020-01-01")),
     cohort_end_date = as.Date(c("2020-01-10"))
   ))
-  expect_warning(cohort1 <- newCohortTable(cdm$cohort1))
+  expect_no_warning(cohort1 <- newCohortTable(cdm$cohort1))
   cdm <- insertTable(cdm, name = "cohort1", table = dplyr::tibble(
     cohort_definition_id = 1L,
     subject_id = 1L,
@@ -429,24 +429,22 @@ test_that("test that tables are casted", {
     cdm$cohort1, cohortSetRef = dplyr::tibble(
       cohort_definition_id = 1L, cohort_name = "cohort1", set = TRUE
     )))
-  expect_warning(cohort4 <- newCohortTable(
+  expect_no_warning(cohort4 <- newCohortTable(
     cdm$cohort1, cohortSetRef = dplyr::tibble(
       cohort_definition_id = 1, cohort_name = "cohort1", set = TRUE
     )))
-  expect_identical(cohort3, cohort4)
   expect_no_warning(cohort5 <- newCohortTable(
     cdm$cohort1, cohortAttritionRef = dplyr::tibble(
       cohort_definition_id = 1L, number_records = 1L, number_subjects = 1L,
       reason_id = 1L, reason = "Individual of interest", excluded_records = 0L,
       excluded_subjects = 0L
     )))
-  expect_warning(cohort6 <- newCohortTable(
+  expect_no_warning(cohort6 <- newCohortTable(
     cdm$cohort1, cohortAttritionRef = dplyr::tibble(
       cohort_definition_id = 1L, number_records = 1L, number_subjects = 1L,
       reason_id = 1L, reason = "Individual of interest", excluded_records = 0,
       excluded_subjects = 0L
     )))
-  expect_identical(cohort5, cohort6)
   expect_no_warning(cohort7 <- newCohortTable(
     cdm$cohort1, cohortCodelistRef = dplyr::tibble(
       cohort_definition_id = 1L, codelist_name = "covid", concept_id = 1L,


### PR DESCRIPTION
Change casting warnings so that integer and numeric are considered equivalent

https://github.com/darwin-eu-dev/CDMConnector/issues/480

